### PR TITLE
Release 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## 0.9.4
 
-- Fix bug where DTTA news articles added after server start aren not available. ([fixes #259](https://github.com/uccser/dthm4kaiako/issues/259))
+- Fix bug where DTTA news articles added after server start are not available. ([fixes #259](https://github.com/uccser/dthm4kaiako/issues/259))
 
 ## 0.9.3
 
-- Fix bug where DTTA news articles are filtered by the wrong timezone. ([fixes #259](https://github.com/uccser/dthm4kaiako/issues/259))
+- Fix bug where DTTA news articles are filtered by the wrong timezone.
 - Fix bug where Rresource 'component of' links do not link correctly. ([fixes #261](https://github.com/uccser/dthm4kaiako/issues/261))
 - Fix date within FAQ question.
 - Update dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.4
+
+- Fix bug where DTTA news articles added after server start aren not available. ([fixes #259](https://github.com/uccser/dthm4kaiako/issues/259))
+
 ## 0.9.3
 
 - Fix bug where DTTA news articles are filtered by the wrong timezone. ([fixes #259](https://github.com/uccser/dthm4kaiako/issues/259))

--- a/dthm4kaiako/config/__init__.py
+++ b/dthm4kaiako/config/__init__.py
@@ -1,6 +1,6 @@
 """Configuration for Django system."""
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num


### PR DESCRIPTION
- Fix bug where DTTA news articles added after server start are not available. ([fixes #259](https://github.com/uccser/dthm4kaiako/issues/259))