### PR TITLE
Release 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.14.2
+
+- Add new dependency for missing library for Google Cloud Storage dependency.
+
 ## 0.14.1
 
-- Update dependency as backup bindings for Google Cloud Storage
+- Update dependency for backup bindings for Google Cloud Storage.
 
 ## 0.14.0
 

--- a/dthm4kaiako/config/__init__.py
+++ b/dthm4kaiako/config/__init__.py
@@ -1,6 +1,6 @@
 """Configuration for Django system."""
 
-__version__ = "0.14.1"
+__version__ = "0.14.2"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/dthm4kaiako/tests/resources/factories.py
+++ b/dthm4kaiako/tests/resources/factories.py
@@ -49,6 +49,7 @@ class ResourceFactory(DjangoModelFactory):
 
     name = Faker('sentence')
     description = Faker('paragraph', nb_sentences=5)
+    published = True
 
     class Meta:
         """Metadata for class."""

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,5 +5,9 @@
 # Django
 # ------------------------------------------------------------------------------
 django-storages[google]==1.7.1  # https://github.com/jschneier/django-storages
-google-cloud-storage==1.15.0
 google-auth==1.6.3  # https://github.com/googleapis/google-auth-library-python
+
+# Extra packages due to missing bindings
+# See: https://github.com/uccser/dthm4kaiako/issues/363
+google-cloud-storage==1.15.0
+google-resumable-media[requests]==0.3.2


### PR DESCRIPTION
- Add new dependency for missing library for Google Cloud Storage dependency.

Related to #363 