### PR TITLE
Stop previous version upon dev deployment and update the expected release date for guide.

### DIFF
--- a/dthm4kaiako/templates/general/home.html
+++ b/dthm4kaiako/templates/general/home.html
@@ -71,7 +71,7 @@
                         View get started guide
                     </a>
                     <div class="card-footer text-muted text-center">
-                        Coming late 2020
+                        Coming 2021
                     </div>
                 </div>
             </div>

--- a/infrastructure/dev-deploy/deploy-app.sh
+++ b/infrastructure/dev-deploy/deploy-app.sh
@@ -43,4 +43,4 @@ gcloud app deploy ./app.yaml --quiet --project=dthm4kaiako-dev
 
 # Publish cron jobs to Google App Engine.
 cp ./infrastructure/dev-deploy/cron.yaml ./cron.yaml
-gcloud app deploy ./cron.yaml --quiet --project=dthm4kaiako-dev
+gcloud app deploy ./cron.yaml --quiet --project=dthm4kaiako-dev --stop-previous-version

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 pytz==2019.3  # https://github.com/stub42/pytz
 python-slugify==4.0.0  # https://github.com/un33k/python-slugify
-Pillow==7.0.0  # https://github.com/python-pillow/Pillow
+Pillow==7.2.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==19.2.0  # https://github.com/hynek/argon2_cffi
 redis>=2.10.6, < 3  # pyup: < 3 # https://github.com/antirez/redis
 filetype==1.0.4  # https://github.com/h2non/filetype.py
@@ -18,7 +18,7 @@ django-recaptcha==2.0.6
 django-autoslug-iplweb==1.9.5  # https://github.com/justinmayer/django-autoslug
 djangorestframework==3.11.0  # https://github.com/encode/django-rest-framework
 coreapi==2.3.3  # https://github.com/core-api/python-client
-django-filter==2.2.0  # https://github.com/carltongibson/django-filter/
+django-filter==2.4.0  # https://github.com/carltongibson/django-filter/
 django-ipware==2.1.0
 django-modelclone==0.7.1
 django-inline-svg==0.1.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r ./base.txt
 
-Sphinx==2.3.1  # https://github.com/sphinx-doc/sphinx
+Sphinx==3.2.1  # https://github.com/sphinx-doc/sphinx
 psycopg2-binary==2.8.4  # https://github.com/psycopg/psycopg2
 
 # Testing


### PR DESCRIPTION
During my research into where our Google Cloud Platform expenditures were coming from, I noticed that for all of our dev sites we were serving more than one version - which was contributing significantly to our costs. We only need to serve the latest version. We can delete these versions manually through the GCP interface but ideally we would be able to do this automatically every time a new version is deployed. I found there is a `--stop-previous-version` [flag](https://cloud.google.com/sdk/gcloud/reference/app/deploy#--stop-previous-version) we can add to our `gcloud deploy` command to stop the previous version upon deployment.

This only works for versions running on an instance with manual scaling (which all of our dev sites do), so will not work for prod deployments (but that's not where our issue lies anyway). We will not know if this works until it is merged.

Includes a text change asked for by Jack.

Dependency updates:
- Update django-filter from 2.2.0 to 2.4.0
- Update Pillow from 7.0.0 to 7.2.0.
- Update Sphinx from 2.3.1 to 3.2.1.