### PR TITLE
Promote new version to default version with every dev deploy.

### DIFF
--- a/infrastructure/dev-deploy/deploy-app.sh
+++ b/infrastructure/dev-deploy/deploy-app.sh
@@ -43,4 +43,4 @@ gcloud app deploy ./app.yaml --quiet --project=dthm4kaiako-dev
 
 # Publish cron jobs to Google App Engine.
 cp ./infrastructure/dev-deploy/cron.yaml ./cron.yaml
-gcloud app deploy ./cron.yaml --quiet --project=dthm4kaiako-dev --stop-previous-version
+gcloud app deploy ./cron.yaml --quiet --project=dthm4kaiako-dev --promote --stop-previous-version


### PR DESCRIPTION
#657 didn't work as expected and according to this [Google discussion](https://groups.google.com/forum/#!topic/google-appengine/eJUQ7NlNkso) we probably need to promote the new version to the default version. Thus with every new deploy every previous version is stopped and the new version is promoted to default version.