### PR TITLE
Set UID of node user to the UID of the host user; add allauth middleware

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start systems
         run: docker compose -f docker-compose.local.yml up -d
       - name: Run Django system check
@@ -32,6 +35,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start systems
         run: docker compose -f docker-compose.local.yml up -d
       - name: Create static files
@@ -55,6 +61,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start systems
         run: docker compose -f docker-compose.local.yml up -d
       - name: Create static files
@@ -131,6 +140,10 @@ jobs:
       - name: Create Docker network
         run: docker network create uccser-development-stack
 
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
+
       - name: Start system
         run: docker compose -f docker-compose.local.yml up -d
 
@@ -170,6 +183,9 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Docker network
         run: docker network create uccser-development-stack
+        # Required for the node service
+      - name: Set DOCKER_UID variable
+        run: echo "DOCKER_UID=$(echo $UID)" >> $GITHUB_ENV
       - name: Start system
         run: docker compose -f docker-compose.local.yml up -d
       - name: Create production static files

--- a/dev
+++ b/dev
@@ -9,6 +9,8 @@
 
 set -e
 
+export DOCKER_UID=$UID
+
 ERROR='\033[0;31m'
 SUCCESS='\033[0;32m'
 CODE='\033[0;36m'

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -31,6 +31,8 @@ services:
         build:
             context: .
             dockerfile: ./infrastructure/local/node/Dockerfile
+            args:
+                DOCKER_UID: ${DOCKER_UID}
         image: dthm4kaiako_local_node
         volumes:
             # https://burnedikt.com/dockerized-node-development-and-mounting-node-volumes/#exclude-node_modules-from-the-mount

--- a/dthm4kaiako/config/settings/base.py
+++ b/dthm4kaiako/config/settings/base.py
@@ -196,6 +196,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#middleware
 MIDDLEWARE = [
+    'allauth.account.middleware.AccountMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',

--- a/infrastructure/local/node/Dockerfile
+++ b/infrastructure/local/node/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:14.17.0-buster
 
+ARG DOCKER_UID=1000
+RUN usermod -u $DOCKER_UID node
+
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \


### PR DESCRIPTION
## Proposed changes

### Set UID of node user to the UID of the host user

See https://github.com/uccser/cs-field-guide/pull/2011

"On multi-user systems, such as the University of Canterbury linux systems, it appears that the node user created by the Nodejs docker base has a different UID to the host user. This is a problem because we use a bind mount, which retains the host users permissions, meaning that the node user doesn't have permission to access the mounted files."

"This PR sets the UID of the node user to the value of the $UID bash shell variable to fix the permission issue."


### Add allauth to middleware
See https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#backwards-incompatible-changes-4

