### PR TITLE
Replace ckeditor with tinyMCE and django-filebrowser-no-grappelli

### DIFF
--- a/dthm4kaiako/ara_ako/models.py
+++ b/dthm4kaiako/ara_ako/models.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 from django.urls import reverse
-from ckeditor_uploader.fields import RichTextUploadingField
+from tinymce.models import HTMLField
 from events.models import Event
 from resources.models import Resource
 
@@ -41,7 +41,7 @@ class AraAkoTeam(models.Model):
     """Model for an Ara Ako team."""
 
     number = models.PositiveSmallIntegerField()
-    description = RichTextUploadingField()
+    description = HTMLField()
     resource = models.OneToOneField(
         Resource,
         verbose_name='Ara Ako team resource',

--- a/dthm4kaiako/config/settings/base.py
+++ b/dthm4kaiako/config/settings/base.py
@@ -361,7 +361,7 @@ FILEBROWSER_SELECT_FORMATS = {
 }
 
 FILEBROWSER_EXTENSIONS = {
-    'Image': ['.jpg','.jpeg','.gif','.png','.tif','.tiff']
+    'Image': ['.jpg', '.jpeg', '.gif', '.png', '.tif', '.tiff']
 }
 
 # django-activeurl

--- a/dthm4kaiako/config/settings/base.py
+++ b/dthm4kaiako/config/settings/base.py
@@ -95,6 +95,7 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # APPS
 # ------------------------------------------------------------------------------
 DJANGO_APPS = [
+    'filebrowser',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -120,14 +121,13 @@ THIRD_PARTY_APPS = [
     'allauth.socialaccount',
     'rest_framework',
     'markdownx',
-    'ckeditor',
-    'ckeditor_uploader',
     'django_activeurl',
     'mapwidgets',
     'captcha',
     'django_filters',
     'modelclone',
     'svg',
+    'tinymce',
 ]
 LOCAL_APPS = [
     'general.apps.GeneralAppConfig',
@@ -336,31 +336,32 @@ ACCOUNT_LOGOUT_ON_GET = True
 SOCIALACCOUNT_ADAPTER = 'users.adapters.SocialAccountAdapter'
 
 
-# ckeditor
+# tinymce (for uploading images in news postings)
 # ------------------------------------------------------------------------------
-CKEDITOR_UPLOAD_PATH = 'text-editor'
-CKEDITOR_ALLOW_NONIMAGE_FILES = False
-CKEDITOR_CONFIGS = {
-    'default': {
-        'width': '100%',
-        'clipboard_defaultContentType': 'text',
-        'tabSpaces': 4,
-        'extraPlugins': ','.join([
-            # 'devtools',  # Used for development
-            'a11yhelp',
-            'uploadimage',
-            'image2',
-            'div',
-            'autolink',
-            'autogrow',
-            'clipboard',
-            'codesnippet',
-            'pastefromword',
-            'widget',
-            'dialog',
-            'dialogui',
-        ]),
-    }
+TINYMCE_DEFAULT_CONFIG = {
+    "theme": "silver",
+    "height": 500,
+    "menubar": False,
+    "plugins": "advlist,autolink,lists,link,image,charmap,print,preview,anchor,"
+    "searchreplace,visualblocks,code,fullscreen,insertdatetime,media,table,paste,"
+    "code,help,wordcount",
+    "toolbar": "undo redo | formatselect | "
+    "bold italic backcolor | alignleft aligncenter "
+    "alignright alignjustify | bullist numlist outdent indent | "
+    "removeformat | image | help",
+}
+
+TINYMCE_FILEBROWSER = True
+
+FILEBROWSER_DIRECTORY = 'text-editor/'
+
+FILEBROWSER_SELECT_FORMATS = {
+    'file': ['Image'],
+    'image': ['Image']
+}
+
+FILEBROWSER_EXTENSIONS = {
+    'Image': ['.jpg','.jpeg','.gif','.png','.tif','.tiff']
 }
 
 # django-activeurl

--- a/dthm4kaiako/config/urls.py
+++ b/dthm4kaiako/config/urls.py
@@ -9,6 +9,7 @@ from django.contrib import admin
 from django.contrib.auth.decorators import login_required
 from django.views import defaults as default_views
 from config.views import get_release_and_commit
+from filebrowser.sites import site
 admin.site.login = login_required(admin.site.login)
 admin.site.site_header = 'dthm4kaiako.ac.nz'
 admin.site.site_title = admin.site.site_header
@@ -28,12 +29,13 @@ urlpatterns = [
     # Accounts application
     path('accounts/', include('allauth.urls')),
     # Admin application
+    path('admin/filebrowser/', site.urls),
     path(settings.ADMIN_URL, admin.site.urls),
     # Utility applications
     path('healthcheck/', HttpResponse),
     path('status/', view=get_release_and_commit, name="get-release-and-commit"),
     path('markdownx/', include('markdownx.urls')),
-    path('ckeditor/', include('ckeditor_uploader.urls')),
+    path('tinymce/', include('tinymce.urls')),
     # path('api/', include('rest_framework.urls')),
     # Redirects
     path('authentic-context-cards/', RedirectView.as_view(pattern_name='learning_area_cards:home', permanent=True)),

--- a/dthm4kaiako/dtta/models.py
+++ b/dthm4kaiako/dtta/models.py
@@ -3,7 +3,7 @@
 from django.db import models
 from django.urls import reverse
 from autoslug import AutoSlugField
-from ckeditor_uploader.fields import RichTextUploadingField
+from tinymce.models import HTMLField
 from utils.get_upload_filepath import get_dtta_news_article_source_upload_path
 
 
@@ -30,7 +30,7 @@ class Page(models.Model):
     )
     order_number = models.PositiveSmallIntegerField(default=1)
     published = models.BooleanField(default=False)
-    content = RichTextUploadingField()
+    content = HTMLField()
 
     def get_absolute_url(self):
         """Return URL of object on website.
@@ -60,7 +60,7 @@ class Project(models.Model):
     date = models.DateField()
     order_number = models.PositiveSmallIntegerField(default=1)
     published = models.BooleanField(default=False)
-    content = RichTextUploadingField()
+    content = HTMLField()
 
     def get_absolute_url(self):
         """Return URL of object on website.
@@ -151,7 +151,7 @@ class NewsArticle(models.Model):
     title = models.CharField(max_length=200)
     slug = AutoSlugField(populate_from='title', always_update=True, null=True)
     datetime = models.DateTimeField()
-    content = RichTextUploadingField()
+    content = HTMLField()
     source = models.ForeignKey(
         NewsArticleSource,
         on_delete=models.CASCADE,

--- a/dthm4kaiako/events/models.py
+++ b/dthm4kaiako/events/models.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils.timezone import now
 from utils.get_upload_filepath import get_event_series_upload_path
 from autoslug import AutoSlugField
-from ckeditor_uploader.fields import RichTextUploadingField
+from tinymce.models import HTMLField
 from django.utils.translation import gettext_lazy as _
 from users.models import Entity
 
@@ -80,7 +80,7 @@ class Location(models.Model):
         choices=REGION_CHOICES,
         default=REGION_CANTERBURY,
     )
-    description = RichTextUploadingField(blank=True)
+    description = HTMLField(blank=True)
     coords = geomodels.PointField()
 
     def __str__(self):
@@ -120,7 +120,7 @@ class Series(models.Model):
 
     name = models.CharField(max_length=200)
     abbreviation = models.CharField(max_length=30)
-    description = RichTextUploadingField()
+    description = HTMLField()
     logo = models.ImageField(
         null=True,
         blank=True,
@@ -159,7 +159,7 @@ class Event(models.Model):
     """Model for an event."""
 
     name = models.CharField(max_length=200)
-    description = RichTextUploadingField()
+    description = HTMLField()
     slug = AutoSlugField(populate_from='get_short_name', always_update=True, null=True)
     # TODO: Only allow publishing if start and end are not null
     published = models.BooleanField(default=False)
@@ -296,7 +296,7 @@ class Session(models.Model):
     """Model for an event session."""
 
     name = models.CharField(max_length=200)
-    description = RichTextUploadingField(blank=True)
+    description = HTMLField(blank=True)
     url = models.URLField(blank=True)
     url_label = models.CharField(max_length=200, blank=True)
     start = models.DateTimeField()

--- a/dthm4kaiako/get_started/models.py
+++ b/dthm4kaiako/get_started/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from autoslug import AutoSlugField
-from ckeditor_uploader.fields import RichTextUploadingField
+from tinymce.models import HTMLField
 from resources.models import Resource
 
 
@@ -14,9 +14,9 @@ class Component(models.Model):
     order_number = models.PositiveSmallIntegerField()
     name = models.CharField(max_length=200)
     slug = AutoSlugField(populate_from='name', always_update=True, null=True)
-    description = RichTextUploadingField()
+    description = HTMLField()
     video_url = models.URLField(blank=True)
-    video_transcript = RichTextUploadingField(blank=True)
+    video_transcript = HTMLField(blank=True)
     # Visibility
     VISIBILITY_HIDDEN = 1
     VISIBILITY_COMING_SOON = 2

--- a/dthm4kaiako/poet/models.py
+++ b/dthm4kaiako/poet/models.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 from django.urls import reverse
-from ckeditor_uploader.fields import RichTextUploadingField
+from tinymce.models import HTMLField
 
 
 class ProgressOutcome(models.Model):
@@ -67,7 +67,7 @@ class Resource(models.Model):
         on_delete=models.CASCADE,
         related_name='resources',
     )
-    content = RichTextUploadingField()
+    content = HTMLField()
 
     def __str__(self):
         """Text representation of object.

--- a/dthm4kaiako/resources/models.py
+++ b/dthm4kaiako/resources/models.py
@@ -15,7 +15,7 @@ import filetype
 from utils.get_upload_filepath import get_resource_upload_path
 from utils.google_drive_api import get_google_drive_mimetype
 from utils.search_utils import concat_field_values
-from ckeditor_uploader.fields import RichTextUploadingField
+from tinymce.models import HTMLField
 from users.models import Entity
 
 ICON_PATH = 'img/icons/'
@@ -158,7 +158,7 @@ class Resource(models.Model):
 
     name = models.CharField(max_length=200)
     slug = AutoSlugField(populate_from='name', always_update=True, null=True)
-    description = RichTextUploadingField()
+    description = HTMLField()
     datetime_added = models.DateTimeField(auto_now_add=True)
     datetime_updated = models.DateTimeField(auto_now=True)
     search_vector = SearchVectorField(null=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,11 @@ django-activeurl==0.2.0  # https://github.com/hellysmile/django-activeurl
 django-allauth==0.61.0
 django-anymail[mailgun]==8.6
 django-autoslug==1.9.9  # https://github.com/justinmayer/django-autoslug
-django-ckeditor==6.7.1
+django-ckeditor==6.7.1 # Todo: Unused, remove.
 django-cors-headers==3.14.0
 django-crispy-forms==1.14.0  # https://github.com/django-crispy-forms/django-crispy-forms
 django-environ==0.11.2
+django-filebrowser-no-grappelli==4.0.2
 django-filter==21.1  # https://github.com/carltongibson/django-filter/
 django-inline-svg==0.1.1
 django-ipware==4.0.2
@@ -16,6 +17,7 @@ django-map-widgets==0.4.2  # https://github.com/erdem/django-map-widgets
 django-model-utils==4.5.0  # https://github.com/jazzband/django-model-utils
 django-modelclone==0.7.1
 django-recaptcha==3.0.0
+django-tinymce==3.6.1 # https://github.com/jazzband/django-tinymce
 djangorestframework==3.15.1  # https://github.com/encode/django-rest-framework
 
 # Web serving
@@ -31,7 +33,7 @@ argon2-cffi==21.3.0
 
 # Resources
 WeasyPrint==52.4
-Pillow==8.2.0
+Pillow==10.3.0
 filetype==1.2.0  # https://github.com/h2non/filetype.py
 
 # Google Cloud Platform


### PR DESCRIPTION
## Proposed changes

We need a fancy editor so users can upload images when in the admin panel. The current editor, `django-ckeditor`, is no longer maintained and has a deprecation warning.

It can be replaced with the tinyMCE editor, which uses `django-filebrowser` to manage user-uploaded files. This also lets us update `Pillow`, which fixes many known vulnerabilities.




